### PR TITLE
Updates for Beat Saber 1.37.1

### DIFF
--- a/SliceDetails/AffinityPatches/ResultsViewControllerPatch.cs
+++ b/SliceDetails/AffinityPatches/ResultsViewControllerPatch.cs
@@ -12,7 +12,7 @@ namespace SliceDetails.AffinityPatches
 		}
 
 		[AffinityPostfix]
-		[AffinityPatch(typeof(ResultsViewController), nameof(ResultsViewController.DisableResultEnvironmentController))]
+		[AffinityPatch(typeof(ResultsViewController), nameof(ResultsViewController.DidDeactivate))]
 		internal void Postfix(ref ResultsViewController __instance) {
 			if(Plugin.Settings.ShowInCompletionScreen)
 				_uiCreator.RemoveFloatingScreen();

--- a/SliceDetails/Installers/SDMenuInstaller.cs
+++ b/SliceDetails/Installers/SDMenuInstaller.cs
@@ -8,6 +8,7 @@ namespace SliceDetails.Installers
 	{
 		public override void InstallBindings() {
 			Container.BindInterfacesAndSelfTo<HoverHintControllerGrabber>().AsSingle();
+			Container.BindInterfacesTo<SettingsViewController>().AsSingle();
 			Container.Bind<GridViewController>().FromNewComponentAsViewController().AsSingle();
 			Container.Bind<UICreator>().AsSingle();
 

--- a/SliceDetails/Plugin.cs
+++ b/SliceDetails/Plugin.cs
@@ -19,10 +19,7 @@ namespace SliceDetails
 		public void Init(IPA.Logging.Logger logger, Config config, Zenjector zenject) {
 			Settings = config.Generated<SettingsStore>();
 
-			BSMLSettings.instance.AddSettingsMenu("SliceDetails", $"SliceDetails.UI.Views.settingsView.bsml", SettingsViewController.instance);
-
 			zenject.UseLogger(logger);
-
 			zenject.Install<SDAppInstaller>(Location.App);
 			zenject.Install<SDMenuInstaller>(Location.Menu);
 			zenject.Install<SDGameInstaller>(Location.StandardPlayer);

--- a/SliceDetails/SliceDetails.csproj
+++ b/SliceDetails/SliceDetails.csproj
@@ -14,19 +14,23 @@
 	
 	<ItemGroup>
 		<Reference Include="BeatmapCore">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
 		</Reference>
 		<Reference Include="BSML">
-		  <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
 		</Reference>
 		<Reference Include="Colors">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll</HintPath>
+		</Reference>
+		<Reference Include="DataModels" Publicize="True">
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="GameplayCore">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
 		</Reference>
 		<Reference Include="SiraUtil">
-		  <HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
 		</Reference>
 		<Reference Include="System" />
 		<Reference Include="System.Core" />
@@ -34,73 +38,73 @@
 		<Reference Include="System.Data.DataSetExtensions" />
 		<Reference Include="System.Data" />
 		<Reference Include="System.Xml" />
-		<Reference Include="Main">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
-		  <Private>False</Private>
+		<Reference Include="Main" Publicize="True">
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="HMLib">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="HMUI">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="IPA.Loader">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Unity.TextMeshPro">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine.AnimationModule">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
 		</Reference>
 		<Reference Include="UnityEngine.AudioModule">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
 		</Reference>
 		<Reference Include="UnityEngine.CoreModule">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine.ImageConversionModule">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
 		</Reference>
 		<Reference Include="UnityEngine.InputLegacyModule">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
 		</Reference>
 		<Reference Include="UnityEngine.PhysicsModule">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
 		</Reference>
 		<Reference Include="UnityEngine.UI">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine.UIElementsModule">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine.UIModule">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine.VRModule">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.VRModule.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.VRModule.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="VRUI">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\VRUI.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\VRUI.dll</HintPath>
 		</Reference>
 		<Reference Include="Zenject">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
 		</Reference>
 		<Reference Include="Zenject-usage">
-		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 	
@@ -119,6 +123,10 @@
 		<PackageReference Include="BeatSaberModdingTools.Tasks" Version="2.0.0-beta4">
 			<IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 	</ItemGroup>
 	

--- a/SliceDetails/UI/AssetLoader.cs
+++ b/SliceDetails/UI/AssetLoader.cs
@@ -6,14 +6,18 @@ namespace SliceDetails.UI
 {
 	internal class AssetLoader
 	{
-		public Sprite spr_arrow { get; }
-		public Sprite spr_dot { get; }
-		public Sprite spr_roundrect { get; }
+		public Sprite CutArrow { get; }
+		public Sprite GradientBackground { get; }
+		public Sprite NoteBackground { get; }
+		public Sprite NoteArrow { get; }
+		public Sprite NoteDot { get; }
 
 		public AssetLoader() {
-			spr_arrow = LoadSpriteFromResource("SliceDetails.Resources.arrow.png");
-			spr_dot = LoadSpriteFromResource("SliceDetails.Resources.dot.png");
-			spr_roundrect = LoadSpriteFromResource("SliceDetails.Resources.bloq.png");
+			NoteArrow = LoadSpriteFromResource("SliceDetails.Resources.arrow.png");
+			CutArrow = LoadSpriteFromResource("SliceDetails.Resources.cut_arrow.png");
+			NoteDot = LoadSpriteFromResource("SliceDetails.Resources.dot.png");
+			GradientBackground = LoadSpriteFromResource("SliceDetails.Resources.bloq_gradient.png");
+			NoteBackground = LoadSpriteFromResource("SliceDetails.Resources.bloq.png");
 		}
 
 		public static Sprite LoadSpriteFromResource(string path) {

--- a/SliceDetails/UI/GridViewController.cs
+++ b/SliceDetails/UI/GridViewController.cs
@@ -91,6 +91,11 @@ namespace SliceDetails.UI
 			_noteCutArrow.gameObject.name = "NoteCutArrow";
 			_noteCutDistance.gameObject.name = "NoteCutDistance";
 
+			_note.sprite = _assetLoader.NoteBackground;
+			_tile.sprite = _assetLoader.GradientBackground;
+			_noteDirArrow.sprite = _assetLoader.NoteArrow;
+			_noteCutArrow.sprite = _assetLoader.CutArrow;
+
 			_sdVersionText.text = $"SliceDetails v{ System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3) }";
 			ReflectionUtil.InvokeMethod<object, TextMeshProUGUI>(_sdVersionText, "Awake"); // For some reason this is necessary
 			_sdVersionText.rectTransform.sizeDelta = new Vector2(40.0f, 10.0f);

--- a/SliceDetails/UI/NoteUI.cs
+++ b/SliceDetails/UI/NoteUI.cs
@@ -85,7 +85,7 @@ namespace SliceDetails.UI
 					break;
 				case OrderedNoteCutDirection.Any:
 					_noteRotation = 0.0f;
-					_directionArrowImage.sprite = assetLoader.spr_dot;
+					_directionArrowImage.sprite = assetLoader.NoteDot;
 					break;
 			}
 

--- a/SliceDetails/UI/SelectedTileIndicator.cs
+++ b/SliceDetails/UI/SelectedTileIndicator.cs
@@ -15,7 +15,7 @@ namespace SliceDetails.UI
 			// Create a new sliced sprite using the existing bloq texture so we don't have to make another resource
 			if (newRoundRect == null) {
 				Vector4 spriteBorder = new Vector4(54, 54, 54, 54);
-				Texture2D spriteTexture = assetLoader.spr_roundrect.texture;
+				Texture2D spriteTexture = assetLoader.NoteBackground.texture;
 				Rect rect = new Rect(0, 0, spriteTexture.width, spriteTexture.height);
 				newRoundRect = Sprite.Create(spriteTexture, rect, new Vector2(0.5f, 0.5f), 200, 1, SpriteMeshType.FullRect, spriteBorder);
 			}
@@ -36,7 +36,7 @@ namespace SliceDetails.UI
 				tileDot.rectTransform.localScale = Vector3.one;
 				tileDot.rectTransform.localPosition = new Vector3((i % 4) * 3.0f - 4.5f, (i / 4) * 3.0f - 3.0f, 0.0f);
 				tileDot.rectTransform.sizeDelta = new Vector2(6.0f, 6.0f);
-				tileDot.sprite = assetLoader.spr_dot;
+				tileDot.sprite = assetLoader.NoteDot;
 				tileDot.type = Image.Type.Simple;
 				tileDot.color = Color.white;
 				tileDot.material = Utilities.ImageResources.NoGlowMat;

--- a/SliceDetails/UI/SettingsViewController.cs
+++ b/SliceDetails/UI/SettingsViewController.cs
@@ -1,55 +1,69 @@
 ﻿using BeatSaberMarkupLanguage.Attributes;
+using BeatSaberMarkupLanguage.Settings;
+using System;
+using Zenject;
 
 namespace SliceDetails.UI
 {
-	internal class SettingsViewController : PersistentSingleton<SettingsViewController>
+    internal class SettingsViewController : IInitializable, IDisposable
 	{
+		private readonly string resourceName = $"SliceDetails.UI.Views.settingsView.bsml";
+
+        public void Initialize() {
+            BSMLSettings.instance.AddSettingsMenu("SliceDetails", resourceName, this);
+        }
+
+		public void Dispose() {
+			BSMLSettings.instance.RemoveSettingsMenu(this);
+		}
+
 		[UIValue("show-pause")]
-		public bool ShowInPauseMenu {
-			get { return Plugin.Settings.ShowInPauseMenu; }
-			set { Plugin.Settings.ShowInPauseMenu = value; }
-		}
+		public bool ShowInPauseMenu
+        {
+            get => Plugin.Settings.ShowInPauseMenu;
+            set => Plugin.Settings.ShowInPauseMenu = value;
+        }
 
-		[UIValue("show-completion")]
+        [UIValue("show-completion")]
 		public bool ShowInCompletionScreen
-		{
-			get { return Plugin.Settings.ShowInCompletionScreen; }
-			set { Plugin.Settings.ShowInCompletionScreen = value; }
-		}
+        {
+            get => Plugin.Settings.ShowInCompletionScreen;
+            set => Plugin.Settings.ShowInCompletionScreen = value;
+        }
 
-		[UIValue("show-handles")]
+        [UIValue("show-handles")]
 		public bool ShowHandle
 		{
-			get { return Plugin.Settings.ShowHandle; }
-			set { Plugin.Settings.ShowHandle = value; }
+			get => Plugin.Settings.ShowHandle;
+			set => Plugin.Settings.ShowHandle = value;
 		}
 
 		[UIValue("show-counts")]
 		public bool ShowSliceCounts
 		{
-			get { return Plugin.Settings.ShowSliceCounts; }
-			set { Plugin.Settings.ShowSliceCounts = value; }
+			get =>	Plugin.Settings.ShowSliceCounts;
+			set => Plugin.Settings.ShowSliceCounts = value;
 		}
 
 		[UIValue("true-offsets")]
 		public bool TrueCutOffsets
 		{
-			get { return Plugin.Settings.TrueCutOffsets; }
-			set { Plugin.Settings.TrueCutOffsets = value; }
+			get => Plugin.Settings.TrueCutOffsets;
+			set	=> Plugin.Settings.TrueCutOffsets = value;
 		}
 
 		[UIValue("count-arcs")]
 		public bool CountArcs
 		{
-			get { return Plugin.Settings.CountArcs; }
-			set { Plugin.Settings.CountArcs = value; }
+			get => Plugin.Settings.CountArcs;
+			set => Plugin.Settings.CountArcs = value;
 		}
 
 		[UIValue("count-chains")]
 		public bool CountChains
 		{
-			get { return Plugin.Settings.CountChains; }
-			set { Plugin.Settings.CountChains = value; }
+			get => Plugin.Settings.CountChains;
+			set => Plugin.Settings.CountChains = value;
 		}
 	}
 }

--- a/SliceDetails/UI/Views/gridView.bsml
+++ b/SliceDetails/UI/Views/gridView.bsml
@@ -1,31 +1,31 @@
-﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
+﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://monkeymanboy.github.io/BSML-Docs/BSMLSchema.xsd'>
 	<vertical child-control-height='true'>
 		<horizontal bg='round-rect-panel' pad='5' horizontal-fit='PreferredSize'>
 			<vertical id='tile-grid'>
 				<horizontal id='tile-row'>
 				</horizontal>
 			</vertical>
-			<clickable-image id='tile' src='SliceDetails.Resources.bloq_gradient.png' default-color='#777777' highlight-color='#eeeeee' preferred-width='10' preferred-height='10' click-event='presentNotesModal'>
-				<!--<image id='tile-dot' src='SliceDetails.Resources.dot.png' size-delta-x='10' size-delta-y='10'></image>-->
-				<text text='' font-size='3' face-color='#ffffff' font-align='Center'></text>
-				<text text='' font-size='2' face-color='#999999' font-align='Center'></text>
+      
+			<clickable-image id='tile' default-color='#777777' highlight-color='#eeeeee' preferred-width='10' preferred-height='10' click-event='presentNotesModal'>
+        <text text='' font-size='3' face-color='#ffffff' font-align='Center' raycast-target='false'/>
+        <text text='' font-size='2' face-color='#999999' font-align='Center' raycast-target='false'/>
 			</clickable-image>
 		</horizontal>
-		<modal id='note-modal' show-event='presentNotesModal' click-off-closes='true' move-to-center='true'>
-			<horizontal id='note-horizontal' bg='round-rect-panel' horizontal-fit='PreferredSize'>
-				<vertical id='note-grid' pad='5' vertical-fit='PreferredSize'>
+	<modal id='note-modal' show-event='presentNotesModal' click-off-closes='true' move-to-center='true'>
+		<horizontal id='note-horizontal' bg='round-rect-panel' horizontal-fit='PreferredSize'>
+			<vertical id='note-grid' pad='5' vertical-fit='PreferredSize'>
 					
-				</vertical>
-				<horizontal id='note-row'>
+			</vertical>
+			<horizontal id='note-row'>
 						
-				</horizontal>
-				<image id='note' src='SliceDetails.Resources.bloq.png' preferred-width='16' preferred-height='16' pad='1' img-color='#777777'>
-					<image id='note-dir-arrow' src='SliceDetails.Resources.arrow.png' size-delta-x='16' size-delta-y='16'></image>
-					<image id='note-cut-arrow' src='SliceDetails.Resources.cut_arrow.png' size-delta-x='16' size-delta-y='16'></image>
-					<image id='note-cut-distance' size-delta-x='16' size-delta-y='16' pivot-x='1.0'></image>
-				</image>
 			</horizontal>
-		</modal>
+			<image id='note' preferred-width='16' preferred-height='16' pad='1' img-color='#777777'>
+				<image id='note-dir-arrow' size-delta-x='16' size-delta-y='16'></image>
+				<image id='note-cut-arrow' size-delta-x='16' size-delta-y='16'></image>
+			<image id='note-cut-distance' size-delta-x='16' size-delta-y='16' pivot-x='1.0'></image>
+			</image>
+		</horizontal>
+	</modal>
 	</vertical>
 	<text id='sd-version' text='SliceDetails v' font-size='2' font-color='#999' font-align='Right' ignore-layout='true' preferred-width='5'/>
 	<button id='reset-button' font-size='2' click-event='askReset' text='Reset' ignore-layout='true' preferred-width='10'></button>

--- a/SliceDetails/UI/Views/settingsView.bsml
+++ b/SliceDetails/UI/Views/settingsView.bsml
@@ -1,4 +1,4 @@
-﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
+﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://monkeymanboy.github.io/BSML-Docs/BSMLSchema.xsd'>
 	<settings-container>
 		<bool-setting text='Show In Pause Menu' value='show-pause' hover-hint='Shows SliceDetails in the pause menu'></bool-setting>
 		<bool-setting text='Show In Completion Screen' value='show-completion' hover-hint='Shows SliceDetails in the level completion screen'></bool-setting>

--- a/SliceDetails/Utils/ColorSchemeManager.cs
+++ b/SliceDetails/Utils/ColorSchemeManager.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
-using static PlayerSaveData;
 
 namespace SliceDetails.Utils
 {
@@ -15,7 +14,7 @@ namespace SliceDetails.Utils
 
 		public static ColorScheme GetMainColorScheme() {
 			if (_colorScheme == null) {
-				ColorSchemesSettings colorSchemesSettings = ReflectionUtil.GetField<PlayerData, PlayerDataModel>(Resources.FindObjectsOfTypeAll<PlayerDataModel>().FirstOrDefault(), "_playerData").colorSchemesSettings;
+				ColorSchemesSettings colorSchemesSettings = Resources.FindObjectsOfTypeAll<PlayerDataModel>().FirstOrDefault()._playerData.colorSchemesSettings;
 				_colorScheme = colorSchemesSettings.GetSelectedColorScheme();
 			}
 			return _colorScheme;


### PR DESCRIPTION
- Add reference to `DataModels.dll` for `PlayerSaveData`
- Add `raycast-target='true'` to text within tiles to fix selection
- Load and assign image sprites manually because BSML loads them asynchronously and we need them before it loads
- Remove `PersistentSingleton` as it's no longer required
- `ResultsViewController.DisableResultEnvironmentController()` doesn't exist anymore, using DidDeactivate instead
- Update BSML schema
- Use AssemblyPublicizer instead of field accessors where possible